### PR TITLE
Fix a build failure in 1.0.4

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -21,6 +21,7 @@ fn main() {
         "cio.c",
         "dwt.c",
         "event.c",
+        "ht_dec.c",
         "image.c",
         "invert.c",
         "j2k.c",


### PR DESCRIPTION
Here is a simple fix of a build failure due to addition of a source file.

Closes #4.