### PR TITLE
Add feature flag `threads` to enable/disable threads support.  Also correct the OpenJPEG version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,9 @@ libc = "0.2.94"
 cc = "1.0.67"
 
 [features]
+default = ["threads"]
+
+# Compile OpenJPEG with thread support.
+threads = []
+
 parallel = ["cc/parallel"]

--- a/build.rs
+++ b/build.rs
@@ -7,13 +7,18 @@ fn main() {
     let target = std::env::var("CARGO_CFG_TARGET_FAMILY").expect("CARGO_CFG_TARGET_FAMILY");
     if target == "windows" {
         cc.define("OPJ_HAVE__ALIGNED_MALLOC", Some("1"));
+        #[cfg(feature = "threads")]
+        cc.define("MUTEX_win32", Some("1"));
     } else {
         cc.define("OPJ_HAVE_POSIX_MEMALIGN", Some("1"));
+        #[cfg(feature = "threads")]
+        cc.define("MUTEX_pthread", Some("1"));
     }
     cc.include(jp2dir);
     cc.include("config");
     cc.define("OPJ_STATIC", Some("1"));
-    cc.define("MUTEX_stub", Some("1")); // FIXME define MUTEX_win32 or MUTEX_pthread
+    #[cfg(not(feature = "threads"))]
+    cc.define("MUTEX_stub", Some("1"));
 
     let files = [
         "thread.c",

--- a/config/opj_config.h
+++ b/config/opj_config.h
@@ -6,5 +6,5 @@
 
 /* Version number. */
 #define OPJ_VERSION_MAJOR 2
-#define OPJ_VERSION_MINOR 3
-#define OPJ_VERSION_BUILD 1
+#define OPJ_VERSION_MINOR 4
+#define OPJ_VERSION_BUILD 0

--- a/config/opj_config_private.h
+++ b/config/opj_config_private.h
@@ -1,7 +1,7 @@
 /* create opj_config_private.h for CMake */
 #define OPJ_HAVE_INTTYPES_H 	1
 
-#define OPJ_PACKAGE_VERSION "2.3.1"
+#define OPJ_PACKAGE_VERSION "2.4.0"
 
 /* Not used by openjp2*/
 /*#define HAVE_MEMORY_H 1*/


### PR DESCRIPTION
This closes issues #1.

Threads support is enabled by default.